### PR TITLE
Fixed sounds in nodes

### DIFF
--- a/nodes.lua
+++ b/nodes.lua
@@ -7,7 +7,7 @@ minetest.register_node("mg_villages:road", {
 	tiles = {"default_gravel.png", "default_dirt.png"},
         is_ground_content = false, -- will not be removed by the cave generator
         groups = {crumbly=2}, -- does not fall
-        sounds = default.node_sound_gravel_defaults,
+        sounds = default.node_sound_gravel_defaults(),
 --        sounds = default.node_sound_dirt_defaults({
 --                footstep = {name="default_gravel_footstep", gain=0.5},
 --                dug = {name="default_gravel_footstep", gain=1.0},
@@ -40,7 +40,7 @@ minetest.register_node("mg_villages:soil", {
 	drop = "default:dirt",
 	is_ground_content = true,
 	groups = {crumbly=3, not_in_creative_inventory=1, grassland = 1, soil=3, wet=1},
-	sounds = default.node_sound_dirt_defaults,
+	sounds = default.node_sound_dirt_defaults(),
 })
 
 minetest.register_node("mg_villages:desert_sand_soil", {
@@ -49,7 +49,7 @@ minetest.register_node("mg_villages:desert_sand_soil", {
 	is_ground_content = true,
 	drop   = "default:desert_sand",
 	groups = {crumbly=3, not_in_creative_inventory = 1, sand=1, desert = 1, soil=3, wet=1},
-	sounds = default.node_sound_sand_defaults,
+	sounds = default.node_sound_sand_defaults(),
 })
 
 
@@ -80,7 +80,7 @@ if( mg_villages.USE_DEFAULT_3D_TORCHES == false ) then
 		},
 		groups = {choppy=2,dig_immediate=3,flammable=1,attached_node=1},
 		legacy_wallmounted = true,
-		sounds = default.node_sound_defaults,
+		sounds = default.node_sound_defaults(),
 		drop   = "default:torch",
 		is_ground_content = false,
 	})


### PR DESCRIPTION
The sounds in node definitions were using a function from the default mod, but wasn't calling it, resulting in a game stopping error. The engine expected a table and got a function, so I added parenthesis to each sound so that a table is returned and used for the sound as expected.